### PR TITLE
Fix empty page titles

### DIFF
--- a/themes/ooni/layouts/index.html
+++ b/themes/ooni/layouts/index.html
@@ -1,4 +1,4 @@
-{{ partial "head.html" }}
+{{ partial "head.html" . }}
 <body class="homepage">
 
  <a href="https://github.com/TheTorProject/ooni-probe">

--- a/themes/ooni/layouts/post/single.html
+++ b/themes/ooni/layouts/post/single.html
@@ -1,4 +1,4 @@
-{{ partial "head.html" }}
+{{ partial "head.html" . }}
 
 <body class="article">
   <div class="container">


### PR DESCRIPTION
Adding this dot allows the `head` partial to access the titles of blog posts and the home page.