### PR TITLE
Allow logging with Tor browser and strict settings

### DIFF
--- a/themes/ooni/static/js/lb-services.js
+++ b/themes/ooni/static/js/lb-services.js
@@ -3240,6 +3240,14 @@ module
 
           if (LoopBackAuth.accessTokenId) {
             config.headers[authHeader] = LoopBackAuth.accessTokenId;
+            // TBB removes Authentication header for security
+            // Workaround that by chaining the token to the URL
+            if (config.url.indexOf("?") < 0) {
+              config.url += "?";
+            } else {
+              config.url += "&";
+            }
+            config.url += "access_token=" + LoopBackAuth.accessTokenId;
           } else if (config.__isGetCurrentUser__) {
             // Return a stub 401 error for User.getCurrent() when
             // there is no user logged in

--- a/themes/ooni/static/js/lb-services.js
+++ b/themes/ooni/static/js/lb-services.js
@@ -3185,7 +3185,7 @@ module
 
     LoopBackAuth.prototype.save = function() {
       var self = this;
-      var storage = this.rememberMe ? localStorage : sessionStorage;
+      var storage = {}; // Avoid leaving traces on local / session storage
       props.forEach(function(name) {
         save(storage, name, self[name]);
       });
@@ -3222,7 +3222,7 @@ module
 
     function load(name) {
       var key = propsPrefix + name;
-      return localStorage[key] || sessionStorage[key] || null;
+      return null;
     }
   })
   .config(['$httpProvider', function($httpProvider) {

--- a/themes/ooni/static/js/lb-services.js
+++ b/themes/ooni/static/js/lb-services.js
@@ -3240,14 +3240,6 @@ module
 
           if (LoopBackAuth.accessTokenId) {
             config.headers[authHeader] = LoopBackAuth.accessTokenId;
-            // TBB removes Authentication header for security
-            // Workaround that by chaining the token to the URL
-            if (config.url.indexOf("?") < 0) {
-              config.url += "?";
-            } else {
-              config.url += "&";
-            }
-            config.url += "access_token=" + LoopBackAuth.accessTokenId;
           } else if (config.__isGetCurrentUser__) {
             // Return a stub 401 error for User.getCurrent() when
             // there is no user logged in


### PR DESCRIPTION
Under certain strict settings Tor browser does not like it when you use sessionStorage and/or localStorage.

This diff removes any reference to such storages and uses instead a dictionary to keep authentication information.

With this diff committed on my staging system I was able to register myself for ADINA'15 from Tor browser.

This was joint work with @alemela and @davideallavena.

Any thoughts?