### PR TITLE
Remove use of .Site.BaseURL, replace with relative URLs

### DIFF
--- a/themes/ooni/layouts/_default/single.html
+++ b/themes/ooni/layouts/_default/single.html
@@ -5,7 +5,7 @@
     <nav>
       <div class="col-1">
         <a href="/">
-          <img src="{{ .Site.BaseURL }}images/ooni-header-mascot.svg" width="25" height="25"/>
+          <img src="../../images/ooni-header-mascot.svg" width="25" height="25"/>
           <h1>OONI</h1>
         </a>
       </div>

--- a/themes/ooni/layouts/documentation/single.html
+++ b/themes/ooni/layouts/documentation/single.html
@@ -7,7 +7,7 @@
   </div>
   <div class="row">
     <div class="col-1 toc">
-      <img class="cover" src="{{ .Site.BaseURL}}/images/tests/{{ .Slug }}.svg" width="200" height="324"/>
+      <img class="cover" src="../../images/tests/{{ .Slug }}.svg" width="200" height="324"/>
       {{ partial "toc-tests.html"}}
     </div>
     <div class="col-2">

--- a/themes/ooni/layouts/event/single.html
+++ b/themes/ooni/layouts/event/single.html
@@ -1,3 +1,4 @@
+{{ .Scratch.Set "basePrefix" "../../" }}
 {{ partial "head.html" . }}
 
 <body class="article" ng-app="adina15">
@@ -5,12 +6,12 @@
     <nav class="event-navbar">
       <div class="col-1">
         <a href="/">
-          <img class="logo" src="{{ .Site.BaseURL }}/images/ooni-header-mascot.svg" width="25" height="25"/>
-          <img class="wordmark" src="{{ .Site.BaseURL }}/images/wordmark.svg" alt="OONI" height="14" width="53"/>
+          <img class="logo" src="../../images/ooni-header-mascot.svg" width="25" height="25"/>
+          <img class="wordmark" src="../../images/wordmark.svg" alt="OONI" height="14" width="53"/>
         </a>
       </div>
       <div class="col-2">
-        {{ partial "nav.html" }}
+        {{ partial "nav.html" . }}
       </div>
     </nav>
   </div>
@@ -25,7 +26,7 @@
       </div>
 
       <div class="event-banner">
-        <img src="{{ .Site.BaseURL }}/{{ .Params.banner_url }}">
+        <img src="../../{{ .Params.banner_url }}">
       </div>
     </div>
 
@@ -51,7 +52,7 @@
 
     <div class="loader-wrapper" ng-show="loading">
       <div class="loader-box">
-        <img src="{{ .Site.BaseURL }}/images/adina-loader.svg">
+        <img src="../../images/adina-loader.svg">
         <span class="loader-message">Loading...</span>
       </div>
     </div>
@@ -440,10 +441,10 @@
 
   </div>
 
-  <script src="{{ .Site.BaseURL }}/vendor/angular/angular.js"></script>
-  <script src="{{ .Site.BaseURL }}/vendor/angular-resource/angular-resource.js"></script>
-  <script src="{{ .Site.BaseURL }}/js/lb-services.js"></script>
-  <script src="{{ .Site.BaseURL }}/js/adina15.js"></script>
+  <script src="../../vendor/angular/angular.js"></script>
+  <script src="../../vendor/angular-resource/angular-resource.js"></script>
+  <script src="../../js/lb-services.js"></script>
+  <script src="../../js/adina15.js"></script>
 -->
 
 </body>

--- a/themes/ooni/layouts/index.html
+++ b/themes/ooni/layouts/index.html
@@ -2,7 +2,7 @@
 <body class="homepage">
 
  <a href="https://github.com/TheTorProject/ooni-probe">
-   <img style="position: absolute; top: 0; left: 0; border: 0;" src="{{ .Site.BaseURL }}images/forkme_left_gray_6d6d6d.png" alt="Fork me on GitHub"/>
+   <img style="position: absolute; top: 0; left: 0; border: 0;" src="images/forkme_left_gray_6d6d6d.png" alt="Fork me on GitHub"/>
  </a>
  <div class="container">
     <nav>
@@ -14,9 +14,9 @@
 
     <header>
       <div class="row">
-        <img class="col-1" class="logo" src="{{ .Site.BaseURL }}images/ooni-header-mascot.svg" width="200" height="200"/>
+        <img class="col-1" class="logo" src="images/ooni-header-mascot.svg" width="200" height="200"/>
         <div class="col-2">
-          <img class="wordmark" src="{{ .Site.BaseURL }}images/wordmark.svg" alt="OONI"/>
+          <img class="wordmark" src="images/wordmark.svg" alt="OONI"/>
           <h2>Open Observatory of Network Interference</h2>
           <p>A free software, global observation network for detecting censorship,
             surveillance and traffic manipulation on the internet</p>
@@ -34,7 +34,7 @@
           </div>
           <div class="col-2"></div>
         </div>
-        <img class="col-3" src="{{ .Site.BaseURL }}images/how-ooni-works.svg" width="680" height="280" />
+        <img class="col-3" src="images/how-ooni-works.svg" width="680" height="280" />
       </div>
     </div>
     <div class="container">
@@ -78,54 +78,54 @@
 
           <tr>
             <td class="tcol-1">DNS spoofing</td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="2"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="2"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="10"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="25"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="3"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="12"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="22"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="12"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="6"/></td>
+            <td><img src="images/dot.svg" width="2"/></td>
+            <td><img src="images/dot.svg" width="2"/></td>
+            <td><img src="images/dot.svg" width="10"/></td>
+            <td><img src="images/dot.svg" width="25"/></td>
+            <td><img src="images/dot.svg" width="3"/></td>
+            <td><img src="images/dot.svg" width="12"/></td>
+            <td><img src="images/dot.svg" width="22"/></td>
+            <td><img src="images/dot.svg" width="12"/></td>
+            <td><img src="images/dot.svg" width="6"/></td>
           </tr>
 
           <tr>
             <td class="tcol-1">HTTP injection</td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="2"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="7"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="10"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="17"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="3"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="1"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="4"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="2"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="0"/></td>
+            <td><img src="images/dot.svg" width="2"/></td>
+            <td><img src="images/dot.svg" width="7"/></td>
+            <td><img src="images/dot.svg" width="10"/></td>
+            <td><img src="images/dot.svg" width="17"/></td>
+            <td><img src="images/dot.svg" width="3"/></td>
+            <td><img src="images/dot.svg" width="1"/></td>
+            <td><img src="images/dot.svg" width="4"/></td>
+            <td><img src="images/dot.svg" width="2"/></td>
+            <td><img src="images/dot.svg" width="0"/></td>
           </tr>
 
           <tr>
             <td class="tcol-1">HTTP blocking</td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="1"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="4"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="2"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="25"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="5"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="13"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="11"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="14"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="20"/></td>
+            <td><img src="images/dot.svg" width="1"/></td>
+            <td><img src="images/dot.svg" width="4"/></td>
+            <td><img src="images/dot.svg" width="2"/></td>
+            <td><img src="images/dot.svg" width="25"/></td>
+            <td><img src="images/dot.svg" width="5"/></td>
+            <td><img src="images/dot.svg" width="13"/></td>
+            <td><img src="images/dot.svg" width="11"/></td>
+            <td><img src="images/dot.svg" width="14"/></td>
+            <td><img src="images/dot.svg" width="20"/></td>
           </tr>
 
           <tr>
             <td class="tcol-1">Tor blocking</td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="10"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="2"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="7"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="24"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="9"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="6"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="1"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="2"/></td>
-            <td><img src="{{ .Site.BaseURL }}images/dot.svg" width="3"/></td>
+            <td><img src="images/dot.svg" width="10"/></td>
+            <td><img src="images/dot.svg" width="2"/></td>
+            <td><img src="images/dot.svg" width="7"/></td>
+            <td><img src="images/dot.svg" width="24"/></td>
+            <td><img src="images/dot.svg" width="9"/></td>
+            <td><img src="images/dot.svg" width="6"/></td>
+            <td><img src="images/dot.svg" width="1"/></td>
+            <td><img src="images/dot.svg" width="2"/></td>
+            <td><img src="images/dot.svg" width="3"/></td>
           </tr>
 
         </table>
@@ -186,26 +186,26 @@
         <h2>Friends and Sponsors</h2>
         <div class="row sponsors">
           <a href="https://www.openrightsgroup.org">
-            <img src="{{ .Site.BaseURL }}sponsors/open-rights-group-logo.png" alt="Open Rights Group" width="154" height="57"/>
+            <img src="sponsors/open-rights-group-logo.png" alt="Open Rights Group" width="154" height="57"/>
           </a>
           <a href="https://greenhost.net">
-            <img src="{{ .Site.BaseURL }}sponsors/greenhost-logo.png" alt="Greenhost" width="183" height="57"/>
+            <img src="sponsors/greenhost-logo.png" alt="Greenhost" width="183" height="57"/>
           </a>
           <a href="https://www.bytemark.co.uk">
-            <img src="{{ .Site.BaseURL }}sponsors/bytemark-logo.png" alt="Bytemark" class="bytemark" width="240" height="30"/>
+            <img src="sponsors/bytemark-logo.png" alt="Bytemark" class="bytemark" width="240" height="30"/>
           </a>
         </div>
         <div class="row sponsors">
           <a href="https://www.measurementlab.net/">
-            <img src="{{ .Site.BaseURL }}sponsors/mlab-logo.png" alt="MLAB" class="mlab" width="183" height="63"/>
+            <img src="sponsors/mlab-logo.png" alt="MLAB" class="mlab" width="183" height="63"/>
           </a>
 
           <a href="https://airvpn.org">
-            <img src="{{ .Site.BaseURL }}sponsors/airvpn-logo.png" alt="AirVPN" class="airvpn" height="63">
+            <img src="sponsors/airvpn-logo.png" alt="AirVPN" class="airvpn" height="63">
           </a>
 
           <a href="https://www.google.com/">
-            <img src="{{ .Site.BaseURL }}sponsors/google-logo.png" alt="Google" class="google" width="183" height="63"/>
+            <img src="sponsors/google-logo.png" alt="Google" class="google" width="183" height="63"/>
           </a>
         </div>
       </div>

--- a/themes/ooni/layouts/lepidopter/single.html
+++ b/themes/ooni/layouts/lepidopter/single.html
@@ -1,16 +1,17 @@
-{{ partial "head.html" }}
+{{ .Scratch.Set "basePrefix" "../../" }}
+{{ partial "head.html" . }}
 
 <body class="article">
   <div class="container">
     <nav>
       <div class="col-1">
         <a href="/">
-          <img src="{{ .Site.BaseURL }}images/ooni-header-mascot.svg" width="25" height="25"/>
+          <img src="../../images/ooni-header-mascot.svg" width="25" height="25"/>
           <h1>OONI</h1>
         </a>
       </div>
       <div class="col-2">
-        {{ partial "nav.html" }}
+        {{ partial "nav.html" . }}
       </div>
     </nav>
   </div>

--- a/themes/ooni/layouts/partials/head.html
+++ b/themes/ooni/layouts/partials/head.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
+{{ $basePrefix := .Scratch.Get "basePrefix" }}
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width"/>
   <title>{{ .Title }}</title>
-	<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/master.css"/>
-	<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/event.css"/>
-	<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/fonts.css"/>
-  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/highlight-default.min.css">
-  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}/images/favicon.png"/>
-  <script src="{{ .Site.BaseURL }}/js/highlight.min.js"></script>
+	<link rel="stylesheet" href="{{ $basePrefix }}css/master.css"/>
+	<link rel="stylesheet" href="{{ $basePrefix }}css/event.css"/>
+	<link rel="stylesheet" href="{{ $basePrefix }}css/fonts.css"/>
+  <link rel="stylesheet" href="{{ $basePrefix }}css/highlight-default.min.css">
+  <link rel="icon" type="image/png" href="{{ $basePrefix }}images/favicon.png"/>
+  <script src="{{ $basePrefix }}js/highlight.min.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
 </head>

--- a/themes/ooni/layouts/partials/nav.html
+++ b/themes/ooni/layouts/partials/nav.html
@@ -1,6 +1,7 @@
-<a href="{{ .Site.BaseURL }}/docs/">Docs</a>
+{{ $basePrefix := .Scratch.Get "basePrefix" }}
+<a href="{{ $basePrefix }}docs/">Docs</a>
 <a href="https://gitweb.torproject.org/ooni-probe.git">Code</a>
 <a href="https://ooni.torproject.org/reports/">Reports</a>
 <a href="https://github.com/thetorproject/ooni-probe#installation">Install</a>
-<a href="{{ .Site.BaseURL }}/lepidopter/lepidopter/">Lepidopter</a>
-<a href="{{ .Site.BaseURL }}/event/adina15/">Events</a>
+<a href="{{ $basePrefix }}lepidopter/lepidopter/">Lepidopter</a>
+<a href="{{ $basePrefix }}event/adina15/">Events</a>

--- a/themes/ooni/layouts/post/single.html
+++ b/themes/ooni/layouts/post/single.html
@@ -1,3 +1,4 @@
+{{ .Scratch.Set "basePrefix" "../../" }}
 {{ partial "head.html" . }}
 
 <body class="article">
@@ -6,12 +7,12 @@
     <nav>
       <div class="col-1">
         <a href="/">
-          <img class="logo" src="{{ .Site.BaseURL }}/images/ooni-header-mascot.svg" width="25" height="25"/>
-          <img class="wordmark" src="{{ .Site.BaseURL }}/images/wordmark.svg" alt="OONI" height="14" width="53"/>
+          <img class="logo" src="../../images/ooni-header-mascot.svg" width="25" height="25"/>
+          <img class="wordmark" src="../../images/wordmark.svg" alt="OONI" height="14" width="53"/>
         </a>
       </div>
       <div class="col-2">
-        {{ partial "nav.html" }}
+        {{ partial "nav.html" . }}
       </div>
     </nav>
 


### PR DESCRIPTION
Currently the site has some HTTPS mixed-content warnings. Looks like it was caused by a build with BaseURL set to `http://ooni.torproject.org/` rather than `https://ooni.torproject.org/`.

This commit removes the use of BaseURL and replaces it with relative URLs, so the site continues to work at both:

- https://ooni.torproject.org/ and
- https://thetorproject.github.io/ooni-web/

Note that there are still absolute URLs used for images etc. in blog posts. This breaks them on https://thetorproject.github.io/ooni-web/. However replacing these with relative URLs would break them in the RSS feed instead. For the time being I have left them as is.