### PR TITLE
Add docker specific make targets to test ooni-web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN wget https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_$
   mv hugo /usr/bin/hugo
 
 # Clone required OONI repositories
-RUN git clone https://github.com/TheTorProject/ooni-web ${OONI_WEB_REPO_DIR} && \
-  git clone https://github.com/TheTorProject/ooni-probe ${OONI_PROBE_REPO_DIR}
+RUN git clone https://github.com/TheTorProject/ooni-probe ${OONI_PROBE_REPO_DIR}
 
 # Generate OONI website
+COPY . ${OONI_WEB_REPO_DIR}
 WORKDIR ${OONI_WEB_REPO_DIR}
 RUN cp ${OONI_PROBE_REPO_DIR}/requirements-docs.txt .
 RUN pip install -r requirements-docs.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine:edge
+
+ENV OONI_PROBE_REPO_DIR=/ooni-probe
+ENV OONI_WEB_REPO_DIR=/ooni-web
+ENV HUGO_VERSION=0.16
+
+# Install hugo and package dependencies to build ooni-web
+RUN apk add --update wget ca-certificates make git py2-pip
+WORKDIR /tmp
+RUN wget https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-64bit.tgz && \
+  tar xzf hugo_${HUGO_VERSION}_linux-64bit.tgz && \
+  rm -r hugo_${HUGO_VERSION}_linux-64bit.tgz && \
+  mv hugo /usr/bin/hugo
+
+# Clone required OONI repositories
+RUN git clone https://github.com/TheTorProject/ooni-web ${OONI_WEB_REPO_DIR} && \
+  git clone https://github.com/TheTorProject/ooni-probe ${OONI_PROBE_REPO_DIR}
+
+# Generate OONI website
+WORKDIR ${OONI_WEB_REPO_DIR}
+RUN cp ${OONI_PROBE_REPO_DIR}/requirements-docs.txt .
+RUN pip install -r requirements-docs.txt
+RUN rm -rf public/* && \
+  hugo --theme=ooni --buildDrafts --baseUrl=http://0.0.0.0:1313
+# Generate and update docs of ooni-probe
+WORKDIR ${OONI_PROBE_REPO_DIR}/docs
+RUN make clean && \
+  make html
+WORKDIR ${OONI_WEB_REPO_DIR}
+RUN cp -R ${OONI_PROBE_REPO_DIR}/docs/build/html/ public/docs/ && \
+  touch public/.nojekyll
+
+# Run hugo server with OONI website
+CMD ["hugo", "server", "--bind=0.0.0.0", "--theme=ooni", "--baseUrl=http://localhost:1313"]

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,14 @@ publish-update: publish update-site
 
 server:
 	hugo server --theme=ooni --baseUrl=http://127.0.0.1:1313 --buildDrafts
+
+docker-build:
+	docker build --no-cache --rm -t ooni-web .
+
+docker-run: docker-build
+	docker run -p 1313:1313 --rm ooni-web
+
+test-site: docker-build
+test-site: docker-run
+
+.PHONY: setup update-site publish publish-update server docker-build docker-run test-site


### PR DESCRIPTION
This patch includes a Dockerfile and the relevant make targets to build
the ooni-web hugo website. One can test the ooni-web website by
visiting: http://localhost:1313/
Party implements:
https://github.com/TheTorProject/ooni-web/issues/92