### PR TITLE
I18n

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,4 +5,5 @@ DefaultContentLanguage = "en"
 
 [Languages]
 [Languages.en]
+[Languages.fr]
 [Languages.pt]

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,8 @@
 baseURL = "https://ooni.torproject.org"
 languageCode = "en-us"
 title = "OONI: Open Observatory of Network Interference"
+DefaultContentLanguage = "en"
+
+[Languages]
+[Languages.en]
+[Languages.pt]

--- a/content/post/brazil-whatsapp-block.md
+++ b/content/post/brazil-whatsapp-block.md
@@ -18,8 +18,6 @@ aliases:
 
 **Measurement period:** 2016-05-02 - 2016-05-03
 
-**[Portoguese Translation] (/post/brazil-whatsapp-block-pt)**
-
 ----------------------------------------------------------------------------------------
 
 **19:10 UTC Saturday, 7 May 2016** Update: Add OONI Explorer measurements links

--- a/content/post/brazil-whatsapp-block.pt.md
+++ b/content/post/brazil-whatsapp-block.pt.md
@@ -6,6 +6,7 @@ tags: ["brazil", "whatsapp"]
 categories: ["report"]
 aliases:
   - /whatsapp-blocked-in-brazil-again-pt
+  - /post/brazil-whatsapp-block-pt
 ---
 
 **Pais:** Brasil
@@ -19,8 +20,6 @@ aliases:
 **Periodo da medição:** 2016-05-02 - 2016-05-03
 
 **Translation by:** Kornelia Friesch
-
-**[Post in original language](/post/brazil-whatsapp-block)**
 
 ----------------------------------------------------------------------------------------
 

--- a/content/post/internet-censorship-catalonia-independence-referendum.fr.md
+++ b/content/post/internet-censorship-catalonia-independence-referendum.fr.md
@@ -6,13 +6,14 @@ tags: ["catalonia", "censorship"]
 categories: ["report"]
 aliases:
   - /internet-censure-catalogne
+  - /post/internet-censure-catalogne
 ---
 
 ![Seized referendum site](/post/catalonia/seized.png)
 
 Image: Catalan Independence Referendum site seized
 
-**Note:** This post was originally published [here](https://ooni.torproject.org/post/internet-censorship-catalonia-independence-referendum/) on 3rd October 2017. Below we provide a French translation by [Tomàs](https://twitter.com/ersikoo).
+**Note:** This post was originally published [here](/post/internet-censorship-catalonia-independence-referendum/) on 3rd October 2017. Below we provide a French translation by [Tomàs](https://twitter.com/ersikoo).
 
 
 Il y a deux jours, la Catalogne a tenu un [référendum](http://time.com/4951665/catalan-referendum-2017/) en vue de l'indépendance de l'Espagne. Alors que le monde attend à voir ce qui va se passer ensuite, on publique cette post afin de partager les preuves des récents [événements de censure](https://api.ooni.io/files/by_country/ES) qui se sont déroulés pendant et avant le référendum.

--- a/themes/ooni/layouts/post/single.html
+++ b/themes/ooni/layouts/post/single.html
@@ -21,7 +21,17 @@
       <span class="author">{{ .Params.author }}</span>
       <span class="date">{{ .Date }}</span>
     </div>
-
+    {{ if .IsTranslated }}
+    <h4>Translation(s):</h4>
+    <ul>
+      {{ range .Translations }}
+      <li>
+        {{/* FIXME: convert that to language params, I've not managed to do that quicly */}}
+        <a href="{{ .Permalink }}">{{ if eq .Lang "en" }}English{{ else if eq .Lang "pt" }}Portuguese{{ else if eq .Lang "fr" }}French{{ else if eq .Lang "es"  }}Spanish{{ else }}{{ .Lang }}{{ end }}: {{ .Title }}</a>
+      </li>
+      {{ end }}
+    </ul>
+    {{ end }}
     {{ .Content }}
   </main>
 </div>

--- a/themes/ooni/layouts/section/post.html
+++ b/themes/ooni/layouts/section/post.html
@@ -24,6 +24,16 @@
               <p class="title">{{ .Title }}</p>
               <p class="byline">{{ .Date.Format "2 Jan 2006" }}</p>
           </a>
+        {{ if .IsTranslated }}
+          {{/* FIXME: looks rather ugly because of bad margins */}}
+          {{ range .Translations }}
+          <ul>
+              {{/* FIXME: convert that to language params, I've not managed to do that quicly */}}
+              <a href="{{ .Permalink }}"><li><p class="title">{{ if eq .Lang "en" }}English{{ else if eq .Lang "pt" }}Portuguese{{ else if eq .Lang "fr" }}French{{ else if eq .Lang "es"  }}Spanish{{ else }}{{ .Lang }}{{ end }}: {{ .Title }}</p></li></a>
+          </ul>
+          {{ end }}
+        {{ else }}
+        {{ end }}
         </div>
       </div>
     {{ end }}


### PR DESCRIPTION
It's mostly OK. I updated style to include cross-references to translations in **other** languages, it looks like that:
![brazil-whatsapp 2017-10-05 14-48-11](https://user-images.githubusercontent.com/21046/31226465-d822393c-a9de-11e7-904f-68e91a8160e3.png)

English text references `pt` text. Old URL is preserved with `alias`.
![brazil-whatsapp 2017-10-05 14-47-56](https://user-images.githubusercontent.com/21046/31226466-d823cefa-a9de-11e7-9a26-c2770448bb5b.png)

There is style issue causing translations to be listed in /post in an a bit weird way (margin looks bad), but I'm not going to fix it right now:
![post-padding 2017-10-05 15-03-51](https://user-images.githubusercontent.com/21046/31226490-f309a578-a9de-11e7-9076-ea7a142835a3.png)

Also, this change generates bunch of useless pages like `/pt/`, `/pt/tags/`, `/pt/post/` and so on. I think that this is not a blocker.