### PR TITLE
Drop `gpg --fetch-keys` from lepidopter installation instructions

### DIFF
--- a/content/install/lepidopter.md
+++ b/content/install/lepidopter.md
@@ -121,12 +121,6 @@ installed depending on your OS.
 
 ### Import the Lepidopter signing key
 
-From the OONI web server:
-
-```
-gpg --fetch-keys https://get.ooni.torproject.org/lepidopter/lepidopter-signing-key.asc
-```
-
 From a keyserver:
 
 ```


### PR DESCRIPTION
`gpg` can't handle https links, gpg2 is required for that, so I'd rather drop this option to avoid confusion.

CC: @anadahz 