### PR TITLE
Make cypherpunks happy again (WRT Google)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,5 @@ deploy:
   repo: OpenObservatory/OpenObservatory.github.io
   target_branch: master
   name: OONI Web Pusher
+  email: admin@openobservatory.org # publishing OONI with deploy@travis-ci.org is ugly
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ install:
 
 script:
   # keep this in-sync with `Makefile`, this copy-pasta is here to track execution time of each step at Travis CI
-  - rm -rf public
+  # `public` directory is a scratchpad for website generator
+  # `design` directory is http://openobservatory.github.io/design/ website for https://github.com/openobservatory/design repo
+  - rm -rf public design
   - bin/hugo --theme=ooni --buildDrafts --baseUrl=https://ooni.torproject.org
   - make -C contrib/ooni-probe/docs clean
   - make -C contrib/ooni-probe/docs html

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ update-site:
 
 # NB: `make publish` is slow as it downloads whole website and re-uploads it back,
 # you should not use it in your daily life, it's a disaster recovery procedure.
+# keep this in-sync with `.travis.yml`
 publish:
-	rm -rf public
+	rm -rf public design
 	hugo --theme=ooni --buildDrafts --baseUrl=https://ooni.torproject.org
 	make -C ${OONI_PROBE_REPO_DIR}/docs clean
 	make -C ${OONI_PROBE_REPO_DIR}/docs html

--- a/themes/ooni/layouts/index.html
+++ b/themes/ooni/layouts/index.html
@@ -215,7 +215,7 @@
             Fingerprint: 4C15 DDA9 96C6 C0CF 48BD 3309 6B29 43F0 0CB1 77B7
             </p>
             <p>
-            There are also <a href="/about/#contact">other ways to contact</a> if email is unsuitable.
+            We can also be reached <a href="/about/#contact">on Jabber</a>.
             </p>
         </div>
       </div>

--- a/themes/ooni/layouts/index.html
+++ b/themes/ooni/layouts/index.html
@@ -214,6 +214,9 @@
             Key ID: 6B2943F00CB177B7<br>
             Fingerprint: 4C15 DDA9 96C6 C0CF 48BD 3309 6B29 43F0 0CB1 77B7
             </p>
+            <p>
+            There are also <a href="/about/#contact">other ways to contact</a> if email is unsuitable.
+            </p>
         </div>
       </div>
 

--- a/themes/ooni/layouts/section/about.html
+++ b/themes/ooni/layouts/section/about.html
@@ -42,6 +42,7 @@
     <strong><a href="/about/risks/">documentation about potential risks</a></strong>.
     </p>
 
+    <a name="contact"></a>
     <h2>Contact</h2>
     <p>
     You can contact the OONI team by sending an email to <strong>contact@openobservatory.org</strong>.</p> 
@@ -54,6 +55,18 @@ Key fingerprint = 4C15 DDA9 96C6 C0CF 48BD  3309 6B29 43F0 0CB1 77B7<br>
 uid       [ultimate] OONI - Open Observatory of Network Interference<br>
 sub   4096R/8EBD2087374399AB 2016-03-23 [expires: 2018-03-26]<br>
     </p>
+
+    <p>If you're uncomfortable with using email for any of reasons (e.g. because of
+    <a href="https://commons.wikimedia.org/wiki/File:Prism-slide-8.jpg">PRISM</a>
+    watching @openobservatory.org mailbox being hosted by
+    <a href="https://gsuite.google.com" rel="nofollow">G Suite</a>),
+    you can contact team members using XMPP with OTR (when people are online):
+    <ul>
+        <li>Maria Xynou, <a href="xmpp:agrabeli@torproject.org">agrabeli@torproject.org</a>: <tt>97808AA2 2DDBEB34 B661871A 7DC5F86C FAE60873</tt></li>
+        <li>Vasilis Ververis, <a href="xmpp:andz@torproject.org">andz@torproject.org</a>: <tt>23771DC4 585B5C3C 3AC28AA7 D9CD0AE1 60AD8A04</tt></li>
+        <li>Arturo Filastò, <a href="xmpp:art@torproject.org">art@torproject.org</a>: <tt>A806A296 75BE770E 3FF36276 BD5B6CF5 A2BD5DE2</tt></li>
+        <li>Leonid Evdokimov, <a href="xmpp:darkk@torproject.org">darkk@torproject.org</a>: <tt>EC4C71CE 0E2E2221 B746D75B 60533F57 816DD5EB</tt></li>
+    </ul>
     </p>
 
     <h2>Friends and Sponsors</h2>

--- a/themes/ooni/layouts/section/about.html
+++ b/themes/ooni/layouts/section/about.html
@@ -56,16 +56,12 @@ uid       [ultimate] OONI - Open Observatory of Network Interference<br>
 sub   4096R/8EBD2087374399AB 2016-03-23 [expires: 2018-03-26]<br>
     </p>
 
-    <p>If you're uncomfortable with using email for any of reasons (e.g. because of
-    <a href="https://commons.wikimedia.org/wiki/File:Prism-slide-8.jpg">PRISM</a>
-    watching @openobservatory.org mailbox being hosted by
-    <a href="https://gsuite.google.com" rel="nofollow">G Suite</a>),
-    you can contact team members using XMPP with OTR (when people are online):
+    <p>Alternatively, you can reach us via XMPP with OTR:
     <ul>
+        <li>Arturo Filastò, <a href="xmpp:art@torproject.org">art@torproject.org</a>: <tt>A806A296 75BE770E 3FF36276 BD5B6CF5 A2BD5DE2</tt></li>
+        <li>Leonid Evdokimov, <a href="xmpp:darkk@torproject.org">darkk@torproject.org</a>: <tt>EC4C71CE 0E2E2221 B746D75B 60533F57 816DD5EB</tt></li>  
         <li>Maria Xynou, <a href="xmpp:agrabeli@torproject.org">agrabeli@torproject.org</a>: <tt>97808AA2 2DDBEB34 B661871A 7DC5F86C FAE60873</tt></li>
         <li>Vasilis Ververis, <a href="xmpp:andz@torproject.org">andz@torproject.org</a>: <tt>23771DC4 585B5C3C 3AC28AA7 D9CD0AE1 60AD8A04</tt></li>
-        <li>Arturo Filastò, <a href="xmpp:art@torproject.org">art@torproject.org</a>: <tt>A806A296 75BE770E 3FF36276 BD5B6CF5 A2BD5DE2</tt></li>
-        <li>Leonid Evdokimov, <a href="xmpp:darkk@torproject.org">darkk@torproject.org</a>: <tt>EC4C71CE 0E2E2221 B746D75B 60533F57 816DD5EB</tt></li>
     </ul>
     </p>
 


### PR DESCRIPTION
AFAIK, most of OONI sources use gmail themselves, so moving OONI away from G Suite is not that practical, but [cypherpunks raise good concern](https://lists.torproject.org/pipermail/tor-project/2017-October/001502.html) that there should be some google-proof way to communicate with OONI team for people having Google or US government as an adversary according to their threat model.

IRC is one of possible channels, but IRC has no well-established OTR support. I think, that self-hosted [@torproject.org XMPP server](https://trac.torproject.org/projects/tor/wiki/org/operations/Infrastructure/Jabber) (that explicitly annoys people who don't use OTR) is a good fallback plan for alike sources.