### PR TITLE
Disable pluralizing section page titles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://ooni.torproject.org"
 languageCode = "en-us"
 title = "OONI: Open Observatory of Network Interference"
 DefaultContentLanguage = "en"
+pluralizeListTitles = false
 
 [Languages]
 [Languages.en]


### PR DESCRIPTION
By default, Hugo pluralizes the page titles resulting in titles like these:
![image](https://user-images.githubusercontent.com/700829/40667247-a60f9fb0-632f-11e8-89b1-4a9229af3874.png)

This fix overrides the default behaviour. Note that it affects Blog section where title changes from changes from `Posts` to `Post`.