### PR TITLE
Edited tags in OONI publications

### DIFF
--- a/content/post/2018-iran-protests-pt2.md
+++ b/content/post/2018-iran-protests-pt2.md
@@ -2,8 +2,8 @@
 title: "Iran Protests: DPI blocking of Instagram (Part 2)"
 author: "Leonid Evdokimov"
 date: "2018-02-14"
-tags: ["technology", "iran", "DNS", "DNS Hijacking", "TCP injections", "DPI"]
-categories: ["blog"]
+tags: ["technology", "iran", "DNS", "DNS Hijacking", "TCP injections", "DPI", "country-ir"]
+categories: ["report"]
 ---
 
 In early January 2018, OONI published a [post](/post/2018-iran-protests/)

--- a/content/post/2018-iran-protests.md
+++ b/content/post/2018-iran-protests.md
@@ -2,8 +2,8 @@
 title: "Iran Protests: OONI data confirms censorship events (Part 1)"
 author: "Maria Xynou, Arturo Filastò"
 date: "2018-01-05"
-tags: ["iran", "censorship"]
-categories: ["blog"]
+tags: ["iran", "censorship", "country-ir"]
+categories: ["report"]
 ---
 
 At this point, you have probably read all about the

--- a/content/post/belarus-fries-onion.md
+++ b/content/post/belarus-fries-onion.md
@@ -2,8 +2,8 @@
 title: "urandom.pcap: Belarus (finally) bans Tor"
 author: "Leonid Evdokimov"
 date: "2016-12-08"
-tags: ["belarus", "TCP injections"]
-categories: ["blog"]
+tags: ["belarus", "TCP injections", "country-by"]
+categories: ["report"]
 ---
 
 **Country:** Belarus

--- a/content/post/berlin-hackathon-2016.md
+++ b/content/post/berlin-hackathon-2016.md
@@ -3,7 +3,7 @@ title: "OONI Hackathon: Join us to explore internet censorship!"
 author: "Maria Xynou"
 date: "2016-10-25"
 tags: ["events", "hackathon"]
-categories: []
+categories: ["blog"]
 ---
 
 ![HACKOONI16](/post/berlin-hackathon/ooni-berlin-hackathon.png)

--- a/content/post/brazil-whatsapp-block.md
+++ b/content/post/brazil-whatsapp-block.md
@@ -2,7 +2,7 @@
 title: "OONI Data Reveals How WhatsApp Was Blocked (Again) in Brazil"
 author: "Vasilis Ververis, Maria Xynou, Will Scott"
 date: "2016-05-06"
-tags: ["brazil", "whatsapp"]
+tags: ["brazil", "whatsapp", "country-br"]
 categories: ["report"]
 aliases:
   - /whatsapp-blocked-in-brazil-again

--- a/content/post/brazil-whatsapp-block.pt.md
+++ b/content/post/brazil-whatsapp-block.pt.md
@@ -2,7 +2,7 @@
 title: "WhatsApp bloqueado (outra vez) no Brasil"
 author: "Vasilis Ververis, Maria Xynou, Will Scott"
 date: "2016-05-06"
-tags: ["brazil", "whatsapp"]
+tags: ["brazil", "whatsapp", "country-br"]
 categories: ["report"]
 aliases:
   - /whatsapp-blocked-in-brazil-again-pt

--- a/content/post/cuba-internet-censorship-2017.md
+++ b/content/post/cuba-internet-censorship-2017.md
@@ -2,7 +2,7 @@
 title: "Measuring Internet Censorship in Cuba's ParkNets"
 author: "Maria Xynou, Arturo Filastò, Simone Basso"
 date: "2017-08-28"
-tags: ["cuba", "censorship"]
+tags: ["cuba", "censorship", "research-report", "country-cu"]
 categories: ["report"]
 ---
 

--- a/content/post/eeep-greek-censorship.md
+++ b/content/post/eeep-greek-censorship.md
@@ -1,7 +1,7 @@
 ---
 title: "EEEP and Greek Internet censorship"
 summary: "Technical analysis of Hellenic gaming commission blacklist in Greece"
-tags: ["greece", "eeep", "DPI", "DNS Hijacking"]
+tags: ["greece", "eeep", "DPI", "DNS Hijacking", "country-gr"]
 author: "Vasilis Ververis, George Kargiotakis, Arturo Filastò, Alexandros Afentoulis"
 categories: ["report"]
 date: "2015-06-10"

--- a/content/post/egypt-censors.md
+++ b/content/post/egypt-censors.md
@@ -2,7 +2,7 @@
 title: "#EgyptCensors: Evidence of recent censorship events in Egypt"
 author: "Maria Xynou (OONI), Vasilis Ververis (OONI), Arturo Filastò (OONI), Wafa Ben Hassine (Access Now)"
 date: "2017-06-19T15:30:00Z"
-tags: ["egypt", "censorship"]
+tags: ["egypt", "censorship", "country-eg"]
 categories: ["report"]
 ---
 

--- a/content/post/egypt-internet-censorship.md
+++ b/content/post/egypt-internet-censorship.md
@@ -2,7 +2,7 @@
 title: "The State of Internet Censorship in Egypt"
 author: "Leonid Evdokimov (OONI), Maria Xynou (OONI), Mohammad El-Taher (AFTE), Hassan Al-Azhary (AFTE), Sarah Mohsen (AFTE)"
 date: "2018-07-02"
-tags: ["egypt", "censorship"]
+tags: ["egypt", "censorship", "research-report", "country-eg"]
 categories: ["report"]
 ---
 

--- a/content/post/egypt-network-interference.md
+++ b/content/post/egypt-network-interference.md
@@ -2,7 +2,7 @@
 title: "Egypt: Media censorship, Tor interference, HTTPS throttling and ads injections?"
 author: "Leonid Evdokimov, Vasilis Ververis"
 date: "2016-10-27"
-tags: ["egypt", "DPI", "TCP injections", "network throttling"]
+tags: ["egypt", "DPI", "TCP injections", "network throttling", "country-eg"]
 categories: ["report"]
 ---
 

--- a/content/post/ethiopia-internet-shutdown-amidst-recent-protests.md
+++ b/content/post/ethiopia-internet-shutdown-amidst-recent-protests.md
@@ -2,7 +2,7 @@
 title: "Ethiopia: Internet Shutdown Amidst Recent Protests?"
 author: "Moses Karanja (CIPIT), Maria Xynou, Arturo Filastò"
 date: "2016-08-10"
-tags: ["ethiopia", "shutdown", "protests"]
+tags: ["ethiopia", "shutdown", "protests", "country-et"]
 categories: ["report"]
 ---
 

--- a/content/post/ethiopia-report.md
+++ b/content/post/ethiopia-report.md
@@ -2,7 +2,7 @@
 title: "Ethiopia: Evidence of social media blocking and internet censorship"
 author: "Maria Xynou (OONI), Arturo Filastò (OONI), Amnesty International, Girma Walabuma"
 date: "2016-12-14"
-tags: ["ethiopia", "DPI", "protests", "whatsapp", "censorship"]
+tags: ["ethiopia", "DPI", "protests", "whatsapp", "censorship", "research-report", "country-et"]
 categories: ["report"]
 ---
 

--- a/content/post/ethiopia-unblocking.md
+++ b/content/post/ethiopia-unblocking.md
@@ -2,8 +2,8 @@
 title: "Ethiopia: Verifying the unblocking of websites"
 author: "Berhan Taye (Access Now), Maria Xynou (OONI), Leonid Evdokimov (OONI), Moses Karanja (University of Toronto)"
 date: "2018-06-29T19:49:00"
-tags: ["ethiopia", "unblocking"]
-categories: []
+tags: ["ethiopia", "unblocking", "country-et"]
+categories: ["report"]
 ---
 
 ![Rally at Meskel Square](/post/ethiopia-unblocking/cover.jpg)

--- a/content/post/examining-internet-blackouts.md
+++ b/content/post/examining-internet-blackouts.md
@@ -3,7 +3,7 @@ title: "Examining internet blackouts through public data sources"
 author: "Maria Xynou, Arturo Filastò"
 date: "2017-03-28T16:39:00"
 tags: ["blackout", "shutdown"]
-categories: []
+categories: ["blog"]
 ---
 
 Pulling the plug on the internet is one of the ways that governments around the

--- a/content/post/gambia-internet-shutdown.md
+++ b/content/post/gambia-internet-shutdown.md
@@ -2,8 +2,8 @@
 title: "The Gambia: Internet Shutdown during 2016 Presidential Election"
 author: "Arturo Filastò (OONI), Arthur Gwagwa (CIPIT), Maria Xynou (OONI)"
 date: "2016-12-09"
-tags: ["gambia", "elections", "shutdown"]
-categories: []
+tags: ["gambia", "elections", "shutdown", "country-gm"]
+categories: ["report"]
 ---
 
 Last week we attempted to perform [OONI network measurement tests](https://github.com/TheTorProject/ooni-probe) in the Gambia

--- a/content/post/hadara-palestine.md
+++ b/content/post/hadara-palestine.md
@@ -3,7 +3,7 @@ title: "Hadara Palestine"
 summary: "This is the technical report on the politically motivated censorship going on in Bethlehem, West Bank"
 author: "Arturo Filastò"
 date: "2012-04-23"
-tags: ["palestine"]
+tags: ["palestine", "country-ps"]
 categories: ["report"]
 aliases:
   - /hadara-palestine.html

--- a/content/post/how-pakistan-blocked-social-media.md
+++ b/content/post/how-pakistan-blocked-social-media.md
@@ -2,7 +2,7 @@
 title: "How Pakistan blocked news outlets, social media sites, and IM apps amidst protests"
 author: "Maria Xynou (OONI), Arturo Filastò (OONI), Shahzad Ahmad (Bytes for All Pakistan), Abdul Salam (Bytes for All Pakistan)"
 date: "2017-11-29"
-tags: ["pakistan", "censorship"]
+tags: ["pakistan", "censorship", "country-pk"]
 categories: ["report"]
 ---
 

--- a/content/post/indonesia-internet-censorship.md
+++ b/content/post/indonesia-internet-censorship.md
@@ -2,7 +2,7 @@
 title: "The State of Internet Censorship in Indonesia"
 author: "Kay Yen Wong (Sinar Project), Maria Xynou (OONI), Arturo Filastò (OONI), Khairil Yusof (Sinar Project),Tan Sze Ming (Sinar Project)"
 date: "2017-05-23"
-tags: ["indonesia", "censorship"]
+tags: ["indonesia", "censorship", "research-report", "country-id"]
 categories: ["report"]
 ---
 

--- a/content/post/internet-censorship-catalonia-independence-referendum.ca.md
+++ b/content/post/internet-censorship-catalonia-independence-referendum.ca.md
@@ -2,7 +2,7 @@
 title: "Evidència de Censura a Internet durant el Referèndum d'Independència de Catalunya"
 author: "Tord Lundström (Virtual Road), Maria Xynou (OONI)"
 date: "2017-10-05"
-tags: ["catalonia", "censorship"]
+tags: ["catalonia", "censorship", "country-es"]
 categories: ["report"]
 ---
 

--- a/content/post/internet-censorship-catalonia-independence-referendum.es.md
+++ b/content/post/internet-censorship-catalonia-independence-referendum.es.md
@@ -2,7 +2,7 @@
 title: "Evidencia de censura en Internet durante el referéndum de independencia de Cataluña"
 author: "Tord Lundström (Virtual Road), Maria Xynou (OONI)"
 date: "2017-10-03"
-tags: ["catalonia", "censorship"]
+tags: ["catalonia", "censorship", "country-es"]
 categories: ["report"]
 ---
 

--- a/content/post/internet-censorship-catalonia-independence-referendum.fr.md
+++ b/content/post/internet-censorship-catalonia-independence-referendum.fr.md
@@ -2,7 +2,7 @@
 title: "Preuve de la censure sur Internet pendant le référendum de l'indépendance de la Catalogne"
 author: "Tord Lundström (Virtual Road), Maria Xynou (OONI)"
 date: "2017-10-05"
-tags: ["catalonia", "censorship"]
+tags: ["catalonia", "censorship", "country-es"]
 categories: ["report"]
 aliases:
   - /internet-censure-catalogne

--- a/content/post/internet-censorship-catalonia-independence-referendum.md
+++ b/content/post/internet-censorship-catalonia-independence-referendum.md
@@ -2,7 +2,7 @@
 title: "Evidence of Internet Censorship during Catalonia's Independence Referendum"
 author: "Tord Lundström (Virtual Road), Maria Xynou (OONI)"
 date: "2017-10-03"
-tags: ["catalonia", "censorship"]
+tags: ["catalonia", "censorship", "country-es"]
 categories: ["report"]
 ---
 

--- a/content/post/iran-internet-censorship.md
+++ b/content/post/iran-internet-censorship.md
@@ -2,7 +2,7 @@
 title: "Internet Censorship in Iran: Network Measurement Findings from 2014-2017"
 author: "Maria Xynou (OONI), Arturo Filastò (OONI), Mahsa Alimardani (ARTICLE 19), Sina Kouhi (ASL19), Kyle Bowen (ASL19), Vmon (ASL19), Amin Sabeti (Small Media)"
 date: "2017-09-28"
-tags: ["iran", "censorship"]
+tags: ["iran", "censorship", "research-report", "country-ir"]
 categories: ["report"]
 ---
 

--- a/content/post/kenya-study.md
+++ b/content/post/kenya-study.md
@@ -2,7 +2,7 @@
 title: "Kenya: Censorship-free internet?"
 author: "Maria Xynou (OONI), Arturo Filastò (OONI), Moses Karanja (CIPIT)"
 date: "2016-12-27"
-tags: ["kenya", "censorship"]
+tags: ["kenya", "censorship", "country-ke"]
 categories: ["report"]
 ---
 

--- a/content/post/malaysia-report.md
+++ b/content/post/malaysia-report.md
@@ -2,7 +2,7 @@
 title: "The State of Internet Censorship in Malaysia"
 author: "Maria Xynou (OONI), Arturo Filastò (OONI), Khairil Yusof (Sinar Project), Tan Sze Ming (Sinar Project)"
 date: "2016-12-20"
-tags: ["malaysia", "censorship"]
+tags: ["malaysia", "censorship", "research-report", "country-my"]
 categories: ["report"]
 ---
 

--- a/content/post/mali-disruptions-amid-2018-election.md
+++ b/content/post/mali-disruptions-amid-2018-election.md
@@ -2,7 +2,7 @@
 title: "Mali: Social media disruptions amid 2018 presidential election?"
 author: "Maria Xynou (OONI), Julie Owono (Internet Sans Frontieres)"
 date: "2018-07-31"
-tags: ["mali", "censorship", "whatsapp", "socialmedia"]
+tags: ["mali", "censorship", "whatsapp", "socialmedia", "country-ml"]
 categories: ["report"]
 ---
 

--- a/content/post/myanmar-report.md
+++ b/content/post/myanmar-report.md
@@ -2,7 +2,7 @@
 title: "The State of Internet Censorship in Myanmar"
 author: "Kay Yen Wong (Sinar Project), Maria Xynou (OONI), Arturo Filastò (OONI), Khairil Yusof (Sinar Project),Tan Sze Ming (Sinar Project), Myanmar ICT for Development Organization (MIDO)"
 date: "2017-03-29T13:31:00"
-tags: ["myanmar", "censorship"]
+tags: ["myanmar", "censorship", "research-report", "country-mm"]
 categories: ["report"]
 ---
 

--- a/content/post/nigeria-internet-censorship.md
+++ b/content/post/nigeria-internet-censorship.md
@@ -2,7 +2,7 @@
 title: "Nigeria: Measuring Internet Censorship"
 author: "Maria Xynou, Leonid Evdokimov"
 date: "2018-06-11"
-tags: ["censorship"]
+tags: ["censorship", "research-report", "country-ng"]
 categories: ["report"]
 ---
 

--- a/content/post/ooni-dev-and-hackathon-2016.md
+++ b/content/post/ooni-dev-and-hackathon-2016.md
@@ -3,7 +3,7 @@ title: "OONI-dev meeting and hackathon 2016"
 author: "Maria Xynou"
 date: "2016-11-22"
 tags: ["events", "hackathon"]
-categories: []
+categories: ["blog"]
 ---
 
 Oonitarians are spread out across the globe, and OONI’s core team is no

--- a/content/post/ooni-mobile-app.md
+++ b/content/post/ooni-mobile-app.md
@@ -1,9 +1,9 @@
 ---
-title: "New ooniprobe Mobile App: Measure Internet Censorship & Performance"
+title: "New OONI Probe Mobile App: Measure Internet Censorship & Performance"
 author: "Maria Xynou, Lorenzo Primiterra, Simone Basso, Arturo Filastò"
 date: "2017-02-09"
 tags: ["censorship", "speed", "performance"]
-categories: []
+categories: ["blog"]
 ---
 
 ![OONI mobile app](/post/ooni-mobile-app/ooni-mobile-app.jpg)

--- a/content/post/ooni-partner-gathering-2017.md
+++ b/content/post/ooni-partner-gathering-2017.md
@@ -3,7 +3,7 @@ title: "OONI Partner Gathering 2017"
 author: "Maria Xynou"
 date: "2017-07-24"
 tags: ["events", "partners"]
-categories: ["report"]
+categories: ["blog"]
 ---
 
 ![OONI Partner Gathering](/post/ooni-partner-gathering-2017/01.jpg)

--- a/content/post/ooni-run.md
+++ b/content/post/ooni-run.md
@@ -3,7 +3,7 @@ title: "OONI Run: Let's fight internet censorship together!"
 author: "Maria Xynou"
 date: "2017-09-27"
 tags: ["internet censorship", "net neutrality"]
-categories: []
+categories: ["blog"]
 ---
 
 ![OONI Run](/post/ooni-run/ooni-run.png)

--- a/content/post/pakistan-internet-censorship.md
+++ b/content/post/pakistan-internet-censorship.md
@@ -2,7 +2,7 @@
 title: "Internet Censorship in Pakistan: Findings from 2014-2017"
 author: "Haroon Baloch (Bytes for All Pakistan), Maria Xynou (OONI), Arturo Filastò (OONI)"
 date: "2017-10-18"
-tags: ["pakistan", "censorship"]
+tags: ["pakistan", "censorship", "research-report", "country-pk"]
 categories: ["report"]
 ---
 

--- a/content/post/parknet-short-documentary-cuba.md
+++ b/content/post/parknet-short-documentary-cuba.md
@@ -2,7 +2,7 @@
 title: "ParkNet: Short Documentary on Internet Censorship in Cuba"
 author: "Arturo Filastò, Maria Xynou, Simone Basso"
 date: "2018-04-23"
-tags: ["cuba", "censorship", "documentary"]
+tags: ["cuba", "censorship", "documentary", "country-cu"]
 categories: ["blog"]
 ---
 

--- a/content/post/sierra-leone-network-disruptions-2018-elections.md
+++ b/content/post/sierra-leone-network-disruptions-2018-elections.md
@@ -2,7 +2,7 @@
 title: "Sierra Leone: Network disruptions amid 2018 runoff elections"
 author: "Maria Xynou (OONI), Leonid Evdokimov (OONI), Arturo Filastò (OONI), Abdul Fatoma (Campaign for Human Rights and Development International)"
 date: "2018-04-05"
-tags: ["sierra leone", "censorship"]
+tags: ["sierra leone", "censorship", "country-sl"]
 categories: ["report"]
 ---
 

--- a/content/post/south-sudan-censorship.md
+++ b/content/post/south-sudan-censorship.md
@@ -2,7 +2,7 @@
 title: "South Sudan: Measuring Internet Censorship in the World's Youngest Nation"
 author: "Maria Xynou (OONI), Kenyi Yasin Abdallah Kenyi (TAHURID), Leonid Evdokimov (OONI), Stanley Nyombe Gore (TAHURID)"
 date: "2018-08-01"
-tags: ["south sudan", "censorship"]
+tags: ["south sudan", "censorship", "country-ss"]
 categories: ["report"]
 ---
 

--- a/content/post/t-mobile-usa-web-guard.md
+++ b/content/post/t-mobile-usa-web-guard.md
@@ -3,7 +3,7 @@ title: "T-Mobile USA Web Guard"
 summary: "Measuring censorship on T-Mobile USA"
 author: "Arturo Filastò"
 date: "2012-03-21"
-tags: ["usa"]
+tags: ["usa", "country-us"]
 categories: ["report"]
 aliases:
   - /t-mobile-usa-web-guard.html

--- a/content/post/tab-tab-come-in.md
+++ b/content/post/tab-tab-come-in.md
@@ -3,7 +3,7 @@ title: "Tab-Tab, Come in! Bypassing Internet blocking to categorize DPI devices"
 summary: "Analysis of censorship in Turkmenistan and Uzbekistan"
 author: "Arturo Filastò and T."
 date: "2013-05-14"
-tags: ["uzbekistan", "turkmenistan"]
+tags: ["uzbekistan", "turkmenistan", "country-tm", "country-uz"]
 categories: ["report"]
 aliases:
   - /tab-tab-come-in-bypassing-internet-blocking-to-categorize-dpi-devices.html

--- a/content/post/thailand-internet-censorship.md
+++ b/content/post/thailand-internet-censorship.md
@@ -2,7 +2,7 @@
 title: "The State of Internet Censorship in Thailand"
 author: "Kay Yen Wong (Sinar Project), Maria Xynou (OONI), Arturo Filastò (OONI), Khairil Yusof (Sinar Project),Tan Sze Ming (Sinar Project), Thai Netizen Network"
 date: "2017-03-20"
-tags: ["thailand", "censorship"]
+tags: ["thailand", "censorship", "research-report", "country-th"]
 categories: ["report"]
 ---
 

--- a/content/post/turkey-internet-access-disruption.md
+++ b/content/post/turkey-internet-access-disruption.md
@@ -2,7 +2,7 @@
 title: "Internet Access Disruption in Turkey - July 2016"
 author: "Emile Aben, Leonid Evdokimov, Maria Xynou"
 date: "2016-07-19"
-tags: ["turkey", "socialmedia"]
+tags: ["turkey", "socialmedia", "country-tr"]
 categories: ["report"]
 ---
 

--- a/content/post/uganda-social-media-blocked.md
+++ b/content/post/uganda-social-media-blocked.md
@@ -2,7 +2,7 @@
 title: "How Uganda blocked social media, again"
 author: "Maria Xynou, Arturo Filastò"
 date: "2016-05-17"
-tags: ["uganda", "socialmedia"]
+tags: ["uganda", "socialmedia", "country-ug"]
 categories: ["report"]
 ---
 

--- a/content/post/web-ui-post.md
+++ b/content/post/web-ui-post.md
@@ -1,9 +1,9 @@
 ---
-title: "OONI releases new web UI: Run censorship tests from your web browser!"
+title: "OONI releases new Web UI: Run censorship tests from your web browser!"
 author: "Maria Xynou, Arturo Filastò, Vasilis Ververis"
 date: "2016-12-13"
 tags: ["wui"]
-categories: ["report"]
+categories: ["blog"]
 ---
 
 ![Image](/post/wui-screenshots/wui-01.png)

--- a/content/post/whatsapp-and-facebook-tests.md
+++ b/content/post/whatsapp-and-facebook-tests.md
@@ -3,7 +3,7 @@ title: "New OONI tests examine the blocking of WhatsApp and Facebook Messenger"
 author: "Maria Xynou"
 date: "2016-12-15"
 tags: ["whatsapp", "facebook", "censorship"]
-categories: []
+categories: ["blog"]
 ---
 
 Today the [Open Observatory of Network Interference

--- a/content/post/zambia-election-monitoring.md
+++ b/content/post/zambia-election-monitoring.md
@@ -2,7 +2,7 @@
 title: "Zambia: Internet censorship during the 2016 general elections?"
 author: "Maria Xynou (OONI), Arturo Filastò (OONI), Moses Karanja (CIPIT), Arthur Gwagwa (CIPIT), Isaac Rutenberg (CIPIT)"
 date: "2016-10-11T10:52:00Z"
-tags: ["zambia"]
+tags: ["zambia", "research-report", "country-zm"]
 categories: ["report"]
 ---
 

--- a/content/post/zambia.md
+++ b/content/post/zambia.md
@@ -2,7 +2,7 @@
 title: "Zambia, a country under Deep Packet Inspection"
 author: "Mr T."
 date: "2013-07-15"
-tags: ["zambia"]
+tags: ["zambia", "country-zm"]
 categories: ["report"]
 aliases:
   - /zambia-a-country-under-deep-packet-inspection.html


### PR DESCRIPTION
I have updated the tags for all OONI (website) publications. This will enable better categorization in the new OONI website, and they'll allow us to link to country-specific publications in relevant OONI Explorer country pages.

The updates in the categorization are based on the following:

# Categories

* "blog" = Announcements based on OONI events, software updates, new software releases, etc. Basically, anything that did not require research based on OONI data.

* "report" = Posts (long and short) reporting on censorship events based on OONI data.

# Tags

* "research-repot" = For research reports that are long enough to potentially deserve a designed pdf (if they don't already have one). These sorts of reports are usually ~ 30-40 pages long.

* "country-xx" (where "xx" is the country code) = For all blogs _and_ reports that are specific to a country.

For consistency, I think it would be good to keep this schema for future publications.