### PR TITLE
Added remaining tags to OONI reports

### DIFF
--- a/content/post/2019-benin-social-media-blocking.md
+++ b/content/post/2019-benin-social-media-blocking.md
@@ -2,7 +2,7 @@
 title: "Benin: Social media blocking and Internet blackout amid 2019 elections"
 author: "Roderick Fanou (CAIDA, UC San Diego), Ramakrishna Padmanabhan (CAIDA, UC San Diego), Arturo Filastò (OONI), Maria Xynou (OONI)"
 date: "2019-04-30"
-tags: ["benin", "censorship"]
+tags: ["benin", "censorship", "country-bj"]
 categories: ["report"]
 ---
 

--- a/content/post/2019-china-wikipedia-blocking.md
+++ b/content/post/2019-china-wikipedia-blocking.md
@@ -2,7 +2,7 @@
 title: "China is now blocking all language editions of Wikipedia"
 author: "iyouport.org, Open Culture Foundation (OCF), Sukhbir Singh (Open Web Fellow, Mozilla Foundation), Arturo Filastò (OONI), Maria Xynou (OONI)"
 date: "2019-05-04"
-tags: ["china", "wikipedia"]
+tags: ["china", "wikipedia", "country-cn"]
 categories: ["report"]
 ---
 

--- a/content/post/2019-china-wikipedia-blocking.zh.md
+++ b/content/post/2019-china-wikipedia-blocking.zh.md
@@ -2,7 +2,7 @@
 title: "中国封锁了所有语言版本的维基百科"
 author: "iyouport.org, Open Culture Foundation (OCF), Sukhbir Singh (Open Web Fellow, Mozilla Foundation), Arturo Filastò (OONI), Maria Xynou (OONI)"
 date: "2019-05-04"
-tags: ["china", "wikipedia"]
+tags: ["china", "wikipedia", "country-cn"]
 categories: ["report"]
 ---
 

--- a/content/post/cuba-referendum.md
+++ b/content/post/cuba-referendum.md
@@ -2,7 +2,7 @@
 title: "Cuba blocks independent media amid 2019 constitutional referendum"
 author: "Eduardo Ernesto Pérez Pujol, Arturo Filastò (OONI), Maria Xynou (OONI)"
 date: "2019-02-26"
-tags: ["cuba", "censorship"]
+tags: ["cuba", "censorship", "country-cu"]
 categories: ["report"]
 ---
 

--- a/content/post/gabon-internet-disruption.md
+++ b/content/post/gabon-internet-disruption.md
@@ -2,7 +2,7 @@
 title: "Internet disruption in Gabon amid coup attempt"
 author: "Philipp Winter, Maria Xynou"
 date: "2019-01-09"
-tags: ["gabon", "blackout"]
+tags: ["gabon", "blackout", "country-ga"]
 categories: ["report"]
 ---
 

--- a/content/post/uganda-social-media-tax.md
+++ b/content/post/uganda-social-media-tax.md
@@ -2,7 +2,7 @@
 title: "Uganda's Social Media Tax through the lens of network measurements"
 author: "Maria Xynou (OONI), Leonid Evdokimov (OONI), Arturo Filastò (OONI), DefendDefenders, with artwork and contributions from POLLICY"
 date: "2018-11-12"
-tags: ["uganda"]
+tags: ["uganda", "research-report", "country-ug"]
 categories: ["report"]
 ---
 

--- a/content/post/venezuela-blocking-wikipedia-and-social-media-2019.md
+++ b/content/post/venezuela-blocking-wikipedia-and-social-media-2019.md
@@ -2,7 +2,7 @@
 title: "From the blocking of Wikipedia to Social Media: Venezuela's Political Crisis"
 author: "Andrés Azpúrua (Venezuela Inteligente / VEsinFiltro), Mariengracia Chirinos (IPYS Venezuela), Arturo Filastò (OONI), Maria Xynou (OONI), Simone Basso (OONI), Kanishk Karan (Digital Forensic Research Lab)"
 date: "2019-01-29"
-tags: ["venezuela", "censorship"]
+tags: ["venezuela", "censorship", "country-ve"]
 categories: ["report"]
 ---
 

--- a/content/post/zimbabwe-protests-social-media-blocking-2019.md
+++ b/content/post/zimbabwe-protests-social-media-blocking-2019.md
@@ -2,7 +2,7 @@
 title: "Zimbabwe protests: Social media blocking and internet blackouts"
 author: "Maria Xynou (OONI), Arturo Filastò (OONI), Tawanda Mugari (Digital Society of Zimbabwe), Natasha Msonza (Digital Society of Zimbabwe)"
 date: "2019-01-23"
-tags: ["zimbabwe", "censorship"]
+tags: ["zimbabwe", "censorship", "country-zw"]
 categories: ["report"]
 ---
 


### PR DESCRIPTION
I added tags to the remaining OONI research reports, published after August 2018 when the last PR of this sort was opened (https://github.com/TheTorProject/ooni-web/pull/228).

@hellais @sarathms The tags added as part of this PR and those from #228 will help with importing relevant research reports in (the new) OONI Explorer country pages.