### PR TITLE
Move the content from the msg web-service into our website

### DIFF
--- a/content/msg/2017-08-23-angola-elections.md
+++ b/content/msg/2017-08-23-angola-elections.md
@@ -1,0 +1,11 @@
+# Angolan Legislative Election 2017
+
+Election day is an important day, but so are the days following an election.
+
+You can actively examine whether and to what extent online information is accessible in Angola. By running ooniprobe, you can examine:
+
+* Whether websites are blocked;
+* Whether systems that could be responsible for censorship or surveillance are present in your network;
+* Net neutrality violations.
+
+Increasing transparency of information controls during political events is important! By running ooniprobe, you can do just that.

--- a/content/msg/2017-09-06-togo.fr.md
+++ b/content/msg/2017-09-06-togo.fr.md
@@ -1,0 +1,5 @@
+# Facebook et WhatsApp bloqués au Togo?
+
+Aujourd'hui, le 6 Septembre 2017, nous avons entendu que Facebook et WhatsApp sont inaccessibles au Togo.
+
+Utilisez ooniprobe pour collecter information indiquant si et comment ils (et d'autres sites) sont bloqués!

--- a/content/msg/2017-09-06-togo.md
+++ b/content/msg/2017-09-06-togo.md
@@ -1,0 +1,6 @@
+# Facebook and WhatsApp blocked in Togo?
+
+Today, 6th September 2017, we heard that Facebook and WhatsApp are inaccessible in Togo. 
+
+Run ooniprobe to collect data showing whether and how they (and other sites) are blocked!
+

--- a/content/msg/2018-01-belarus-test-blocking-of-charter97-org.md
+++ b/content/msg/2018-01-belarus-test-blocking-of-charter97-org.md
@@ -1,0 +1,14 @@
+# Belarus: Test blocking of charter97.org
+
+Reporters Without Borders reported the blocking of news outlet charter97.org in Belarus: https://rsf.org/en/news/blocking-leading-belarusian-news-website-seen-test-eu
+
+You can test this site with OONI Probe to examine whether and how it is being blocked. In addition to network measurement data, you will also receive relevant circumvention advice.
+
+Simply [click on this link](https://run.ooni.io/nettest?tn=web_connectivity&ta=%7B%22urls%22%3A%5B%22https%3A%2F%2Fcharter97.org%22%5D%7D&mv=1.2.0) (& open it with your OONI Probe mobile app) to test charter97.org with OONI Probe. 
+
+To view the results:
+
+1. Tap on the menu icon on the top left corner in your OONI Probe app
+2. Tap on "Past Tests"
+3. Tap on "Web Connectivity"
+4. Tap on "View" next to charter97.org

--- a/content/msg/2018-07-19-ux-survey.md
+++ b/content/msg/2018-07-19-ux-survey.md
@@ -1,0 +1,13 @@
+# Help us improve OONI Probe
+
+Thanks for using OONI Probe! We're excited to hear more about your experience with OONI Probe so that
+we can improve it.
+
+Please take a few minutes to complete our survey:
+[https://ooniuxteam.typeform.com/to/a1P0cn](https://ooniuxteam.typeform.com/to/a1P0cn)
+
+Alternatively, you can fill out the survey using Tor's self-hosted
+version of it:
+[https://storm.torproject.org/shared/VpAFK13fdAozTGTolFd2EsT1CkLY8-YlBLbRERy5EwI](https://storm.torproject.org/shared/VpAFK13fdAozTGTolFd2EsT1CkLY8-YlBLbRERy5EwI)
+
+Thank you!

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,8 +7,6 @@ HUGO_VERSION = "0.58.2"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
-https://msg.ooni.io/en/messages/2017-09-06-togo
-
 [[redirects]]
   from = "https://msg.ooni.io/en/messages/*"
   to = "https://ooni.org/msg/:splat"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,15 @@ command = "make netlify"
 HUGO_VERSION = "0.58.2"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
+
+https://msg.ooni.io/en/messages/2017-09-06-togo
+
+[[redirects]]
+  from = "https://msg.ooni.io/en/messages/*"
+  to = "https://ooni.org/msg/:splat"
+  status = 301
+
+[[redirects]]
+  from = "https://msg.ooni.io/fr/messages/*"
+  to = "https://ooni.org/fr/msg/:splat"
+  status = 301


### PR DESCRIPTION
This allows us to deprecate the msg.ooni.io host.