### PR TITLE
Blog links refresh

### DIFF
--- a/assets/css/master.css
+++ b/assets/css/master.css
@@ -555,31 +555,51 @@ header .wordmark {
 /* ================================================================== */
 /* Blog */
 
-.blog-summary {
+.blog-title {
   margin-bottom: 2rem;
 }
 
-.blog-summary a {
-  display: block;
-  color: inherit;
+.blog-link {
+  margin-bottom: 2rem;
 }
 
-.blog-summary p.title {
+.blog-link-sm {
+  margin-bottom: 1rem; 
+}
+
+.blog-link-title {
+  display: block; 
+  color: inherit;
   margin-bottom: 0.2rem;
 }
 
-.blog-summary p.title-translation {
-    margin: 0;
-    padding: 0;
-    font-size: 0.8rem;
+.blog-link-title:hover {
+  color: inherit;
 }
 
-.blog-summary p.title-translation a {
+.blog-link-translations {
+    margin-bottom: 2px;
+    font-size: 0.875rem;
+}
+
+.blog-link-translations a {
   text-decoration: none;
   color: #0588cb;
 }
-.blog-summary p.title-translation a:hover {
+
+.blog-link-translations a:hover {
   text-decoration: underline;
+}
+
+.blog-link-translations a:first-child {
+  margin-left: 4px;
+}
+
+.blog-link-translations a:not(:last-child)::after {
+  display: inline-block;
+  content: '•';
+  color: #000;
+  margin: 0 4px;
 }
 
 h1.article-title {
@@ -587,8 +607,9 @@ h1.article-title {
 }
 
 .byline {
-  color: #c1c1c1;
-  font-size: 0.8rem;
+  color: #757575;
+  font-size: 0.875rem;
+  margin-bottom: 0;
 }
 
 .byline .author::after {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,13 +39,15 @@
         <div class="col-lg-3 col-md-12">
           <h2 class="overlined">Research</h2>
         </div>
-       <div class="col-lg-9 col-md-12 blog-summary">
+       <div class="col-lg-9 col-md-12">
          {{ with .Site.Taxonomies.categories.report }}
            {{ range first 5 . }}
-            <a href="{{ .RelPermalink }}">
-                <p class="title">{{ .Title }}</p>
-                <p class="byline">{{ .Date.Format "2 Jan 2006" }}</p>
-            </a>
+            <div class="blog-link-sm">
+              <a class="blog-link-title" href="{{ .RelPermalink }}">
+                {{ .Title }}
+              </a>
+              <p class="byline">{{ .Date.Format "2 Jan 2006" }}</p>
+            </div>
             {{ end }}
           {{ end }}
           <a class="read-more" href="/reports/">View all</a>
@@ -84,13 +86,15 @@
         <div class="col-lg-3 col-md-12">
           <h2 class="overlined">Blog</h2>
         </div>
-        <div class="col-lg-9 col-md-12 blog-summary">
+        <div class="col-lg-9 col-md-12">
          {{ with .Site.Taxonomies.categories.blog }}
          {{ range first 5 . }}
-          <a href="{{ .RelPermalink }}">
-              <p class="title">{{ .Title }}</p>
+            <div class="blog-link-sm">
+              <a class="blog-link-title" href="{{ .RelPermalink }}">
+                {{ .Title }}
+              </a>
               <p class="byline">{{ .Date.Format "2 Jan 2006" }}</p>
-          </a>
+            </div>
           {{ end }}
           {{ end }}
           <a class="read-more" href="/blog/">View all</a>

--- a/layouts/partials/language-titles.html
+++ b/layouts/partials/language-titles.html
@@ -1,0 +1,21 @@
+{{ $languages := dict
+  "ar" "Arabic"
+  "ca" "Catalan"
+  "de" "German"
+  "en" "English"
+  "es" "Spanish"
+  "fa" "Persian"
+  "fr" "French"
+  "pt" "Portuguese"
+  "ru" "Russian"
+  "sw" "Swahili"
+  "tr" "Turkish"
+  "zh" "Chinese"
+  "vi" "Vietnamese"
+}}
+
+{{ with index $languages . }}
+  {{ . }}
+{{ else }}
+  {{ . }}
+{{ end }}

--- a/layouts/section/blog.html
+++ b/layouts/section/blog.html
@@ -1,25 +1,29 @@
 {{ define "main" }}
-<div class="container">
-  <h1>{{ .Title }}</h1>
-  <main class="col">
-    {{ with .Site.Taxonomies.categories.blog }}
-    {{ range . }}
 
-      <div class="row blog-summary">
+<div class="container">
+  <h1 class="blog-title">{{ .Title }}</h1>
+  <main class="col">
+    {{ range .Site.Taxonomies.categories.blog }}
+
+      <div class="row blog-link">
         <div>
-          <a href="{{ .RelPermalink }}" style="margin-bottom: 0">
-            <p class="title">{{ .Title }}</p>
+          <a href="{{ .RelPermalink }}" class="blog-link-title">
+            {{ .Title }}
           </a>
           {{ if .IsTranslated }}
-            <p class="title-translations">Translations: {{ range .Translations }}<a style="display: inline-block;margin-bottom: 0;padding-right: 10px" href="{{ .RelPermalink }}">{{ if eq .Lang "en" }}English{{ else if eq .Lang "pt" }}Portuguese{{ else if eq .Lang "fr" }}French{{ else if eq .Lang "es"  }}Spanish{{ else if eq .Lang "ca"  }}Catalan{{ else }}{{ .Lang }}{{ end }}</a>{{ end }}
+            <p class="blog-link-translations">Translations: 
+            {{ range .Translations }}
+              <a href="{{ .RelPermalink }}">
+                {{ partial "language-titles.html" .Lang }}
+              </a>
+            {{ end }}
             </p>
           {{ else }}
           {{ end }}
-          <p class="byline" style="margin-bottom: 0">{{ .Date.Format "2 Jan 2006" }}</p>
+          <p class="byline">{{ .Date.Format "2 Jan 2006" }}</p>
         </div>
       </div>
 
-    {{ end }}
     {{ end }}
   </main>
 </div>

--- a/layouts/section/post.html
+++ b/layouts/section/post.html
@@ -1,20 +1,26 @@
 {{ define "main" }}
+
 <div class="container">
-  <h1>Research Reports & Blog Posts</h1>
+  <h1 class="blog-title">Research Reports & Blog Posts</h1>
   <main class="col">
     {{ range where .Data.Pages.ByDate.Reverse "Section" "post" }}
 
-      <div class="row blog-summary">
+      <div class="row blog-link">
         <div>
-          <a href="{{ .RelPermalink }}" style="margin-bottom: 0">
-            <p class="title">{{ .Title }}</p>
+          <a href="{{ .RelPermalink }}" class="blog-link-title">
+            {{ .Title }}
           </a>
-          <p class="byline" style="margin-bottom: 0">{{ .Date.Format "2 Jan 2006" }}</p>
           {{ if .IsTranslated }}
-            <p>Translations: {{ range .Translations }}<a style="display: inline-block;margin-bottom: 0;padding-right: 10px" href="{{ .RelPermalink }}">{{ if eq .Lang "en" }}English{{ else if eq .Lang "pt" }}Portuguese{{ else if eq .Lang "fr" }}French{{ else if eq .Lang "es"  }}Spanish{{ else if eq .Lang "ca"  }}Catalan{{ else }}{{ .Lang }}{{ end }}</a>{{ end }}
+            <p class="blog-link-translations">Translations: 
+            {{ range .Translations }}
+              <a href="{{ .RelPermalink }}">
+                {{ partial "language-titles.html" .Lang }}
+              </a>
+            {{ end }}
             </p>
           {{ else }}
           {{ end }}
+          <p class="byline">{{ .Date.Format "2 Jan 2006" }}</p>
         </div>
       </div>
 

--- a/layouts/section/reports.html
+++ b/layouts/section/reports.html
@@ -1,27 +1,31 @@
 {{ define "main" }}
 
 <div class="container">
-  <h1>{{ .Title }}</h1>
+  <h1 class="blog-title">{{ .Title }}</h1>
   <main class="col">
     {{ range .Site.Taxonomies.categories.report }}
 
-      <div class="row blog-summary">
+      <div class="row blog-link">
         <div>
-          <a href="{{ .RelPermalink }}" style="margin-bottom: 0">
-            <p class="title">{{ .Title }}</p>
+          <a href="{{ .RelPermalink }}" class="blog-link-title">
+            {{ .Title }}
           </a>
           {{ if .IsTranslated }}
-            <p class="title-translation">Translations: {{ range .Translations }}<a style="display: inline-block;margin-bottom: 0;padding-right: 10px" href="{{ .RelPermalink }}">{{ if eq .Lang "en" }}English{{ else if eq .Lang "pt" }}Portuguese{{ else if eq .Lang "fr" }}French{{ else if eq .Lang "es"  }}Spanish{{ else if eq .Lang "ca"  }}Catalan{{ else }}{{ .Lang }}{{ end }}</a>{{ end }}
+            <p class="blog-link-translations">Translations: 
+            {{ range .Translations }}
+              <a href="{{ .RelPermalink }}">
+                {{ partial "language-titles.html" .Lang }}
+              </a>
+            {{ end }}
             </p>
           {{ else }}
           {{ end }}
-          <p class="byline" style="margin-bottom: 0">{{ .Date.Format "2 Jan 2006" }}</p>
+          <p class="byline">{{ .Date.Format "2 Jan 2006" }}</p>
         </div>
       </div>
 
     {{ end }}
   </main>
-
 </div>
 
 {{ end }}


### PR DESCRIPTION
### Changes in this PR:
- Added a partial that shows the right language title for its shortcode
- Removed unused `archetypes` directory
- Tweaked the way blog links look on the index page – now only the title is a clickable link
- Gave some breathing space between the page title and the links
- Increased the post date font size and made its font color more contrasting
- Increased the font size for translations and revamped the separators between different languages.

Redesign
| before | after |
|--------|--------|
| ![ooni org_reports_](https://github.com/ooni/ooni.org/assets/15676655/3f3eaeb1-2008-46d1-ba20-1817323182b7) | ![127 0 0 1_1313_reports_](https://github.com/ooni/ooni.org/assets/15676655/df467c54-f17c-4fd8-b31d-f06c540e634b) |


