### PR TITLE
Added Aaron to the OONI Team page

### DIFF
--- a/content/about/team/index.md
+++ b/content/about/team/index.md
@@ -32,5 +32,7 @@ submenu:
 
 {{<team-member name="Maja Komel" role="Frontend Engineer" email="maja@ooni.org" pgpkey="A22363F51398A95B593F94C8231F093C7F5D7A45">}}
 
+{{<team-member name="Aaron Gibson" role="Backend Developer" email="aaron@ooni.org">}}
+
 
 {{</team-listing>}}


### PR DESCRIPTION
This PR updates the [OONI Team page](https://ooni.org/about/team), adding Aaron Gibson. 
